### PR TITLE
Fix delete move watched folder

### DIFF
--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -31,6 +31,7 @@ public:
   bool nodeExists(int wd);
   void removeDirectory(int wd);
   void renameDirectory(int fromWd, std::string fromName, int toWd, std::string toName);
+  bool existWatchedPath();
 
   ~InotifyTree();
 private:
@@ -96,6 +97,7 @@ private:
   std::map<int, InotifyNode *> *mInotifyNodeByWatchDescriptor;
   std::unordered_set<ino_t> inodes;
   InotifyNode *mRoot;
+  std::string mWatchedPath;
 
   friend class InotifyNode;
 };

--- a/includes/osx/FSEventsService.h
+++ b/includes/osx/FSEventsService.h
@@ -51,6 +51,7 @@ private:
   std::string mPath;
   RunLoop *mRunLoop;
   std::shared_ptr<EventQueue> mQueue;
+  bool mRootChanged;
 };
 
 #endif

--- a/includes/win32/Watcher.h
+++ b/includes/win32/Watcher.h
@@ -18,7 +18,7 @@ class Watcher
     ~Watcher();
 
     bool isRunning() const { return mRunning; }
-    std::string getError() const;
+    std::string getError();
 
   private:
     void run();
@@ -34,11 +34,15 @@ class Watcher
 
     std::string getUTF8Directory(std::wstring path) ;
 
+    std::wstring Watcher::getWatchedPath();
+    void Watcher::checkWatchedPath();
+
     std::atomic<bool> mRunning;
     SingleshotSemaphore mHasStartedSemaphore;
     SingleshotSemaphore mIsRunningSemaphore;
     mutable std::mutex mErrorMutex;
     std::string mError;
+    std::wstring mWatchedPath;
 
     const std::wstring mPath;
     std::shared_ptr<EventQueue> mQueue;

--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -108,10 +108,6 @@ void InotifyEventLoop::work() {
       isDirectoryRemoval = event->mask & (uint32_t)(IN_IGNORED | IN_DELETE_SELF);
       isDirectoryEvent = event->mask & (uint32_t)(IN_ISDIR);
 
-      if (!isDirectoryRemoval && *event->name <= 31) {
-        continue;
-      }
-
       if (event->mask & (uint32_t)(IN_ATTRIB | IN_MODIFY)) {
         modify();
       } else if (event->mask & (uint32_t)IN_CREATE) {
@@ -133,7 +129,6 @@ void InotifyEventLoop::work() {
 
         renameStart();
       } else if (event->mask & (uint32_t)IN_MOVE_SELF) {
-        inotifyService->remove(event->wd, event->name);
         inotifyService->removeDirectory(event->wd);
       }
     } while((position += sizeof(struct inotify_event) + event->len) < bytesRead);

--- a/src/linux/InotifyService.cpp
+++ b/src/linux/InotifyService.cpp
@@ -58,12 +58,12 @@ void InotifyService::dispatchRename(int fromWd, std::string fromName, int toWd, 
 }
 
 std::string InotifyService::getError() {
-  if (!isWatching()) {
-    return "Service shutdown unexpectedly";
+  if (mTree != NULL && mTree->hasErrored()) {
+    return mTree->getError();
   }
 
-  if (mTree->hasErrored()) {
-    return mTree->getError();
+  if (!isWatching()) {
+    return "Service shutdown unexpectedly";
   }
 
   return "";

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -19,8 +19,10 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
     watchName = path.substr(location + 1);
   }
 
+  mWatchedPath = directory + "/" + watchName;
+
   struct stat file;
-  if (stat((directory + "/" + watchName).c_str(), &file) < 0) {
+  if (stat(mWatchedPath.c_str(), &file) < 0) {
     mRoot = NULL;
     return;
   }
@@ -40,6 +42,11 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
     mRoot = NULL;
     return;
   }
+}
+
+bool InotifyTree::existWatchedPath() {
+  struct stat file;
+  return stat(mWatchedPath.c_str(), &file) >= 0;
 }
 
 void InotifyTree::addDirectory(int wd, std::string name, EmitCreatedEvent emitCreatedEvent) {
@@ -71,6 +78,9 @@ bool InotifyTree::getPath(std::string &out, int wd) {
 }
 
 bool InotifyTree::hasErrored() {
+  if (!existWatchedPath()) {
+    mError = "Service shutdown: root path changed (renamed or deleted)";
+  }
   return mError != "";
 }
 
@@ -94,6 +104,7 @@ void InotifyTree::removeDirectory(int wd) {
   if (parent == NULL) {
     delete mRoot;
     mRoot = NULL;
+    setError("Service shutdown: root path changed (renamed or deleted)");
     return;
   }
 

--- a/src/osx/RunLoop.cpp
+++ b/src/osx/RunLoop.cpp
@@ -56,7 +56,7 @@ void RunLoop::work() {
     pathsToWatch,
     kFSEventStreamEventIdSinceNow,
     latency,
-    kFSEventStreamCreateFlagFileEvents
+    kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot
   );
 
   FSEventStreamScheduleWithRunLoop(mEventStream, mRunLoop, kCFRunLoopDefaultMode);


### PR DESCRIPTION
To be consistent in the three platforms these commits will make to return the error:
`Service shutdown: root path changed (renamed or deleted)`
when the watched folder is deleted or renamed.